### PR TITLE
fix: Resolve issue with CustomDateTime date property not retaining multiple values

### DIFF
--- a/siwe/siwe.py
+++ b/siwe/siwe.py
@@ -100,6 +100,10 @@ class CustomDateTime(str):
     Meant to enable transitivity of deserialisation and serialisation.
     """
 
+    @property
+    def date(self):
+        return isoparse(self)
+
     @classmethod
     def __get_validators__(cls):
         """Retrieve the validate method."""
@@ -108,7 +112,6 @@ class CustomDateTime(str):
     @classmethod
     def validate(cls, v: str):
         """Validate the format."""
-        cls.date = isoparse(v)
         return cls(v)
 
 


### PR DESCRIPTION
Resolved a bug where the date property of the CustomDateTime class would only retain the value of the last occurrence when multiple properties, such as expiration_time and not_before, were present at the same time.